### PR TITLE
Add support for SFTP SSH key authentication

### DIFF
--- a/lib/SftpClient.js
+++ b/lib/SftpClient.js
@@ -3,7 +3,7 @@ const FileParser = require('ftp/lib/parser')
 const { PassThrough } = require('stream')
 
 class SftpClient {
-  constructor ({ host, port = 21, user, password }) {
+  constructor ({ host, port = 22, user, password }) {
     this.host = host
     this.port = port
     this.user = user

--- a/lib/SftpClient.js
+++ b/lib/SftpClient.js
@@ -1,4 +1,3 @@
-const fs = require('fs-extra')
 const SFTP = require('sftp-promises')
 const FileParser = require('ftp/lib/parser')
 const { PassThrough } = require('stream')
@@ -21,7 +20,7 @@ class SftpClient {
       port: this.port,
       username: this.user,
       password: this.password,
-      privateKey: this.privateKey && await fs.readFile(this.privateKey),
+      privateKey: this.privateKey,
       passphrase: this.passphrase
     }
 

--- a/lib/SftpClient.js
+++ b/lib/SftpClient.js
@@ -1,24 +1,31 @@
+const fs = require('fs-extra')
 const SFTP = require('sftp-promises')
 const FileParser = require('ftp/lib/parser')
 const { PassThrough } = require('stream')
 
 class SftpClient {
-  constructor ({ host, port = 22, user, password }) {
+  constructor ({ host, port = 22, user, password, privateKey, passphrase }) {
     this.host = host
     this.port = port
     this.user = user
     this.password = password
+    this.privateKey = privateKey
+    this.passphrase = passphrase
     this.client = new SFTP()
     this.session = null
   }
 
   async connect () {
-    this.session = await this.client.session({
+    const options = {
       host: this.host,
       port: this.port,
       username: this.user,
-      password: this.password
-    })
+      password: this.password,
+      privateKey: this.privateKey && await fs.readFile(this.privateKey),
+      passphrase: this.passphrase
+    }
+
+    this.session = await this.client.session(options)
 
     return this.session
   }

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -1,5 +1,6 @@
 /* global describe, expect, it */
 
+const fs = require('fs')
 const list = require('../list')
 const FtpServer = require('./support/FtpServer')
 const SftpServer = require('./support/SftpServer')
@@ -35,7 +36,7 @@ describe('list', () => {
     [
       'on a SFTP server with private key',
       () => new SftpServer({ user: 'test', password: '1234' }),
-      { password: undefined, privateKey: 'test/support/test.key' }
+      { password: undefined, privateKey: fs.readFileSync('test/support/test.key') }
     ]
   ])('lists files from the given directory %s', async (label, serverFactory, additionalOptions) => {
     await withServer(serverFactory, async (server) => {

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -14,23 +14,34 @@ describe('list', () => {
   it.each([
     [
       'on a FTP server with anonymous user',
-      () => new FtpServer()
+      () => new FtpServer(),
+      {}
     ],
     [
       'on a FTP server with username/password',
-      () => new FtpServer({ user: 'test', password: '1234' })
+      () => new FtpServer({ user: 'test', password: '1234' }),
+      {}
     ],
     [
       'on a SFTP server with anonymous user',
-      () => new SftpServer()
+      () => new SftpServer(),
+      {}
     ],
     [
       'on a SFTP server with username/password',
-      () => new SftpServer({ user: 'test', password: '1234' })
+      () => new SftpServer({ user: 'test', password: '1234' }),
+      {}
+    ],
+    [
+      'on a SFTP server with private key',
+      () => new SftpServer({ user: 'test', password: '1234' }),
+      { password: undefined, privateKey: 'test/support/test.key' }
     ]
-  ])('lists files from the given directory %s', async (label, serverFactory) => {
+  ])('lists files from the given directory %s', async (label, serverFactory, additionalOptions) => {
     await withServer(serverFactory, async (server) => {
-      const stream = await list({ pathname: 'data', ...server.options })
+      const options = { ...server.options, ...additionalOptions }
+
+      const stream = await list({ pathname: 'data', ...options })
       const filenames = await getStream.array(stream)
 
       expect(filenames).toEqual(['data/abc.txt', 'data/xyz.txt'])

--- a/test/move.test.js
+++ b/test/move.test.js
@@ -38,7 +38,7 @@ describe('move', () => {
     [
       'on a SFTP server with private key',
       () => new SftpServer({ user: 'test', password: '1234' }),
-      { password: undefined, privateKey: 'test/support/test.key' }
+      { password: undefined, privateKey: fs.readFileSync('test/support/test.key') }
     ]
   ])('moves a file from the given place to another place %s', async (label, serverFactory, additionalOptions) => {
     await withServer(serverFactory, async (server) => {

--- a/test/move.test.js
+++ b/test/move.test.js
@@ -17,22 +17,33 @@ describe('move', () => {
   it.each([
     [
       'on a FTP server with anonymous user',
-      () => new FtpServer()
+      () => new FtpServer(),
+      {}
     ],
     [
       'on a FTP server with username/password',
-      () => new FtpServer({ user: 'test', password: '1234' })
+      () => new FtpServer({ user: 'test', password: '1234' }),
+      {}
     ],
     [
       'on a SFTP server with anonymous user',
-      () => new SftpServer()
+      () => new SftpServer(),
+      {}
     ],
     [
       'on a SFTP server with username/password',
-      () => new SftpServer({ user: 'test', password: '1234' })
+      () => new SftpServer({ user: 'test', password: '1234' }),
+      {}
+    ],
+    [
+      'on a SFTP server with private key',
+      () => new SftpServer({ user: 'test', password: '1234' }),
+      { password: undefined, privateKey: 'test/support/test.key' }
     ]
-  ])('moves a file from the given place to another place %s', async (label, serverFactory) => {
+  ])('moves a file from the given place to another place %s', async (label, serverFactory, additionalOptions) => {
     await withServer(serverFactory, async (server) => {
+      const options = { ...server.options, ...additionalOptions }
+
       const root = resolve(__dirname, 'support/tmp/move')
       const original = resolve(__dirname, 'support/data/xyz.txt')
       const source = resolve(root, 'xyz.txt')
@@ -43,7 +54,7 @@ describe('move', () => {
 
       const input = new Readable({ read: () => input.push(null) })
 
-      const stream = await move({ source: 'tmp/move/xyz.txt', target: 'tmp/move/xyz.moved', ...server.options })
+      const stream = await move({ source: 'tmp/move/xyz.txt', target: 'tmp/move/xyz.moved', ...options })
       input.pipe(stream)
       await getStream(stream)
       const content = await fs.readFile(target)

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -1,5 +1,6 @@
 /* global describe, expect, it */
 
+const fs = require('fs')
 const read = require('../read')
 const FtpServer = require('./support/FtpServer')
 const SftpServer = require('./support/SftpServer')
@@ -35,7 +36,7 @@ describe('read', () => {
     [
       'on a SFTP server with private key',
       () => new SftpServer({ user: 'test', password: '1234' }),
-      { password: undefined, privateKey: 'test/support/test.key' }
+      { password: undefined, privateKey: fs.readFileSync('test/support/test.key') }
     ]
   ])('read file from the given path %s', async (label, serverFactory, additionalOptions) => {
     await withServer(serverFactory, async (server) => {

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -14,23 +14,34 @@ describe('read', () => {
   it.each([
     [
       'on a FTP server with anonymous user',
-      () => new FtpServer()
+      () => new FtpServer(),
+      {}
     ],
     [
       'on a FTP server with username/password',
-      () => new FtpServer({ user: 'test', password: '1234' })
+      () => new FtpServer({ user: 'test', password: '1234' }),
+      {}
     ],
     [
       'on a SFTP server with anonymous user',
-      () => new SftpServer()
+      () => new SftpServer(),
+      {}
     ],
     [
       'on a SFTP server with username/password',
-      () => new SftpServer({ user: 'test', password: '1234' })
+      () => new SftpServer({ user: 'test', password: '1234' }),
+      {}
+    ],
+    [
+      'on a SFTP server with private key',
+      () => new SftpServer({ user: 'test', password: '1234' }),
+      { password: undefined, privateKey: 'test/support/test.key' }
     ]
-  ])('read file from the given path %s', async (label, serverFactory) => {
+  ])('read file from the given path %s', async (label, serverFactory, additionalOptions) => {
     await withServer(serverFactory, async (server) => {
-      const stream = await read({ filename: 'data/xyz.txt', ...server.options })
+      const options = { ...server.options, ...additionalOptions }
+
+      const stream = await read({ filename: 'data/xyz.txt', ...options })
       const content = await getStream(stream)
 
       expect(content).toBe('987\n654')

--- a/test/support/SftpServer.js
+++ b/test/support/SftpServer.js
@@ -51,11 +51,20 @@ class FileSystem extends ImplFileSystem {
   }
 
   async authenticate (session, request) {
-    if (request.method === 'none') {
-      return true
-    } else if (request.method !== 'password' ||
+    const validMethods = ['password', 'publickey', 'none']
+    const method = request.method
+
+    if (!validMethods.includes(method)) {
+      return validMethods
+    }
+
+    if (
+      (method === 'none' && this.username) ||
+      (method === 'password' && (
         request.username !== this.username ||
-        request.password !== this.password) {
+        request.password !== this.password
+      ))
+    ) {
       throw new PermissionDeniedError()
     }
   }

--- a/test/support/fs.js
+++ b/test/support/fs.js
@@ -9,6 +9,7 @@ const readFile = promisify(fs.readFile)
 const rmdir = promisify(rimraf)
 
 module.exports = {
+  ...fs,
   copyFile,
   createReadStream,
   mkdir,


### PR DESCRIPTION
Adds `privateKey` and `passphrase` options to SFTP client. `privateKey` should be the path to the private key file.

This PR also changes the default SFTP port (21 -> 22) and fixes authentication in the test SFTP server.

Fixes #5 