### PR TITLE
fix: avoid random timing problem in sftp with PassThrough wrapper

### DIFF
--- a/lib/SftpClient.js
+++ b/lib/SftpClient.js
@@ -1,4 +1,5 @@
 import ftpParser from 'ftp/lib/parser.js'
+import { PassThrough } from 'readable-stream'
 import SFTP from 'sftp-promises'
 const { parseListEntry } = ftpParser
 
@@ -46,7 +47,12 @@ class SftpClient {
   }
 
   async read (path) {
-    return createReadStream(this.client, path, this.session)
+    const stream = await createReadStream(this.client, path, this.session)
+    const through = new PassThrough()
+
+    stream.pipe(through)
+
+    return through
   }
 
   async write (path) {


### PR DESCRIPTION
The following error shows up randomly:

```
Error: No response from server
at cleanupRequests (./node_modules/ssh2/lib/protocol/SFTP.js:2493:15)
at SFTP.push (./node_modules/ssh2/lib/protocol/SFTP.js:191:7)
at onCHANNEL_CLOSE (./node_modules/ssh2/lib/utils.js:50:13)
at ChannelManager.cleanup (./node_modules/ssh2/lib/utils.js:200:7)
at Socket.<anonymous> (./node_modules/ssh2/lib/client.js:769:21)
at Socket.emit (node:events:390:28)
at TCP.<anonymous> (node:net:687:12)
Error: No response from server
at cleanupRequests (./node_modules/ssh2/lib/protocol/SFTP.js:2493:15)
at SFTP.push (./node_modules/ssh2/lib/protocol/SFTP.js:191:7)
at onCHANNEL_CLOSE (./node_modules/ssh2/lib/utils.js:50:13)
at ChannelManager.cleanup (./node_modules/ssh2/lib/utils.js:200:7)
at Socket.<anonymous> (./node_modules/ssh2/lib/client.js:769:21)
at Socket.emit (node:events:390:28)
at TCP.<anonymous> (node:net:687:12)
```
It looks like cleaning up the closed connection doesn't work if it's done too fast. The `PassThrough` wrapper adds an async layer for the close event handling. That fixes the problem. No test is included cause it was not possible to reproduce the problem in a smaller setup.