### PR TITLE
Use file-names as parameters for keys

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -32,14 +32,20 @@ function getClientClass (protocol = 'ftp') {
   }
 }
 
-const validExtensions = ['.pem', '.key', '.pub']
-
-async function getPrivateKey ({ privateKey }) {
-  if (privateKey && typeof privateKey === 'string' &&
-    validExtensions.includes(path.extname(privateKey).toLowerCase())) {
-    const absolutePath = path.resolve(privateKey)
+async function maybeFromFile (str) {
+  try {
+    const absolutePath = path.resolve(str)
     await fs.access(absolutePath)
     return fs.readFile(absolutePath)
+  } catch (err) {
+    return undefined
+  }
+}
+
+async function getPrivateKey ({ privateKey }) {
+  if (privateKey && typeof privateKey === 'string') {
+    const contents = await maybeFromFile(privateKey)
+    return contents ?? privateKey
   }
   return privateKey
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "sftp-promises": "^1.4.1"
   },
   "devDependencies": {
+    "assert-throws-async": "^3.0.0",
     "c8": "^7.7.3",
     "codecov": "^3.8.2",
     "ftp-srv": "^4.2.0",

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -37,7 +37,10 @@ describe('list', () => {
       'on a SFTP server with private key',
       () => new SftpServer({ user: 'test', password: '1234' }),
       { password: undefined, privateKey: readFileSync('test/support/test.key') }
-    ]
+    ], [
+      'on a SFTP server with private key specified as a file',
+      () => new SftpServer({ user: 'test', password: '1234' }),
+      { password: undefined, privateKey: 'test/support/test.key' }]
   ].forEach(([label, serverFactory, additionalOptions]) => {
     it(`lists files from the given directory ${label}`, async () => {
       await withServer(serverFactory, async server => {

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -40,7 +40,8 @@ describe('list', () => {
     ], [
       'on a SFTP server with private key specified as a file',
       () => new SftpServer({ user: 'test', password: '1234' }),
-      { password: undefined, privateKey: 'test/support/test.key' }]
+      { password: undefined, privateKey: 'test/support/test.key' }
+    ]
   ].forEach(([label, serverFactory, additionalOptions]) => {
     it(`lists files from the given directory ${label}`, async () => {
       await withServer(serverFactory, async server => {

--- a/test/move.test.js
+++ b/test/move.test.js
@@ -41,7 +41,10 @@ describe('move', () => {
       'on a SFTP server with private key',
       () => new SftpServer({ user: 'test', password: '1234' }),
       { password: undefined, privateKey: fs.readFileSync('test/support/test.key') }
-    ]
+    ], [
+      'on a SFTP server with private key specified as a file',
+      () => new SftpServer({ user: 'test', password: '1234' }),
+      { password: undefined, privateKey: 'test/support/test.key' }]
   ].forEach(([label, serverFactory, additionalOptions]) => {
     it(`moves a file from the given place to another place ${label}`, async () => {
       await withServer(serverFactory, async server => {

--- a/test/move.test.js
+++ b/test/move.test.js
@@ -44,7 +44,8 @@ describe('move', () => {
     ], [
       'on a SFTP server with private key specified as a file',
       () => new SftpServer({ user: 'test', password: '1234' }),
-      { password: undefined, privateKey: 'test/support/test.key' }]
+      { password: undefined, privateKey: 'test/support/test.key' }
+    ]
   ].forEach(([label, serverFactory, additionalOptions]) => {
     it(`moves a file from the given place to another place ${label}`, async () => {
       await withServer(serverFactory, async server => {

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -58,20 +58,6 @@ describe('read', () => {
       })
     })
 
-  it('fails if file is specified and does not exist', async () => {
-    const serverFactory = () => new SftpServer({ user: 'test', password: '1234' })
-    const additionalOptions = {
-      password: undefined,
-      privateKey: 'test/support/does-not-exist.key'
-    }
-    await withServer(serverFactory, async server => {
-      const options = { ...server.options, ...additionalOptions }
-      await assertThrows(async () => {
-        await read({ filename: 'data/xyz.txt', ...options })
-      }, Error, /ENOENT: no such file or directory/)
-    })
-  })
-
   it('fails if key is malformed', async () => {
     const serverFactory = () => new SftpServer({ user: 'test', password: '1234' })
     const additionalOptions = {
@@ -81,7 +67,7 @@ describe('read', () => {
     await withServer(serverFactory, async server => {
       const options = { ...server.options, ...additionalOptions }
       await assertThrows(async () => {
-         await read({ filename: 'data/xyz.txt', ...options })
+        await read({ filename: 'data/xyz.txt', ...options })
       }, Error, /Cannot parse privateKey/)
     })
   })

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -15,23 +15,36 @@ describe('read', () => {
 
   ;[
     [
-      'on a FTP server with anonymous user', () => new FtpServer(), {}], [
+      'on a FTP server with anonymous user',
+      () => new FtpServer(),
+      {}
+    ],
+    [
       'on a FTP server with username/password',
       () => new FtpServer({ user: 'test', password: '1234' }),
-      {}], [
-      'on a SFTP server with anonymous user', () => new SftpServer(), {}], [
+      {}
+    ],
+    [
+      'on a SFTP server with anonymous user',
+      () => new SftpServer(),
+      {}
+    ],
+    [
       'on a SFTP server with username/password',
       () => new SftpServer({ user: 'test', password: '1234' }),
-      {}], [
+      {}
+    ],
+    [
       'on a SFTP server with private key',
       () => new SftpServer({ user: 'test', password: '1234' }),
-      {
-        password: undefined,
-        privateKey: readFileSync('test/support/test.key')
-      }], [
+      { password: undefined, privateKey: readFileSync('test/support/test.key') }
+    ],
+    [
       'on a SFTP server with private key specified as a file',
       () => new SftpServer({ user: 'test', password: '1234' }),
-      { password: undefined, privateKey: 'test/support/test.key' }]].forEach(
+      { password: undefined, privateKey: 'test/support/test.key' }
+    ]
+  ].forEach(
     ([label, serverFactory, additionalOptions]) => {
       it(`read file from the given path ${label}`, async () => {
         await withServer(serverFactory, async server => {
@@ -68,7 +81,7 @@ describe('read', () => {
     await withServer(serverFactory, async server => {
       const options = { ...server.options, ...additionalOptions }
       await assertThrows(async () => {
-        await read({ filename: 'data/xyz.txt', ...options })
+         await read({ filename: 'data/xyz.txt', ...options })
       }, Error, /Cannot parse privateKey/)
     })
   })

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -1,5 +1,6 @@
 import { strictEqual } from 'assert'
 import { readFileSync } from 'fs'
+import assertThrows from 'assert-throws-async'
 import getStream from 'get-stream'
 import { describe, it } from 'mocha'
 import read from '../read.js'
@@ -14,40 +15,61 @@ describe('read', () => {
 
   ;[
     [
-      'on a FTP server with anonymous user',
-      () => new FtpServer(),
-      {}
-    ],
-    [
+      'on a FTP server with anonymous user', () => new FtpServer(), {}], [
       'on a FTP server with username/password',
       () => new FtpServer({ user: 'test', password: '1234' }),
-      {}
-    ],
-    [
-      'on a SFTP server with anonymous user',
-      () => new SftpServer(),
-      {}
-    ],
-    [
+      {}], [
+      'on a SFTP server with anonymous user', () => new SftpServer(), {}], [
       'on a SFTP server with username/password',
       () => new SftpServer({ user: 'test', password: '1234' }),
-      {}
-    ],
-    [
+      {}], [
       'on a SFTP server with private key',
       () => new SftpServer({ user: 'test', password: '1234' }),
-      { password: undefined, privateKey: readFileSync('test/support/test.key') }
-    ]
-  ].forEach(([label, serverFactory, additionalOptions]) => {
-    it(`read file from the given path ${label}`, async () => {
-      await withServer(serverFactory, async server => {
-        const options = { ...server.options, ...additionalOptions }
+      {
+        password: undefined,
+        privateKey: readFileSync('test/support/test.key')
+      }], [
+      'on a SFTP server with private key specified as a file',
+      () => new SftpServer({ user: 'test', password: '1234' }),
+      { password: undefined, privateKey: 'test/support/test.key' }]].forEach(
+    ([label, serverFactory, additionalOptions]) => {
+      it(`read file from the given path ${label}`, async () => {
+        await withServer(serverFactory, async server => {
+          const options = { ...server.options, ...additionalOptions }
 
-        const stream = await read({ filename: 'data/xyz.txt', ...options })
-        const content = await getStream(stream)
+          const stream = await read({ filename: 'data/xyz.txt', ...options })
+          const content = await getStream(stream)
 
-        strictEqual(content, '987\n654')
+          strictEqual(content, '987\n654')
+        })
       })
+    })
+
+  it('fails if file is specified and does not exist', async () => {
+    const serverFactory = () => new SftpServer({ user: 'test', password: '1234' })
+    const additionalOptions = {
+      password: undefined,
+      privateKey: 'test/support/does-not-exist.key'
+    }
+    await withServer(serverFactory, async server => {
+      const options = { ...server.options, ...additionalOptions }
+      await assertThrows(async () => {
+        await read({ filename: 'data/xyz.txt', ...options })
+      }, Error, /ENOENT: no such file or directory/)
+    })
+  })
+
+  it('fails if key is malformed', async () => {
+    const serverFactory = () => new SftpServer({ user: 'test', password: '1234' })
+    const additionalOptions = {
+      password: undefined,
+      privateKey: 'malformed'
+    }
+    await withServer(serverFactory, async server => {
+      const options = { ...server.options, ...additionalOptions }
+      await assertThrows(async () => {
+        await read({ filename: 'data/xyz.txt', ...options })
+      }, Error, /Cannot parse privateKey/)
     })
   })
 })


### PR DESCRIPTION
req: https://github.com/zazuko/barnard59-ftp/issues/17

This pull request  enables

- to use file names instead in addition to strings.

Only the extensions: ['.pem', '.key', '.pub'] will be considered
